### PR TITLE
replaced isomorphic-unfetch with node-fetch

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import fetch from 'isomorphic-unfetch';
+import fetch from 'node-fetch';
 import { stringify } from 'node:querystring';
 import type { AccessToken, CurrentlyPlaying, Track } from 'spotify-types';
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "isomorphic-unfetch": "^3.1.0"
+    "node-fetch": "^3.2.2"
   },
   "ava": {
     "extensions": {


### PR DESCRIPTION
I have replaced isomorphic-unfetch with node-fetch without receiving any errors during tests.

fixes: https://github.com/rocktimsaikia/spotify-mini/issues/11