### PR TITLE
add accesToken to client + add limit to getLastPlayed

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -22,6 +22,10 @@ type CurrentlyPlayingOptions = {
   fallbackToLastPlayed?: boolean;
 };
 
+type CurrentlyPlayingResponse = ResponseTrack & {
+  isPlaying: boolean;
+}
+
 const filterResponse = (track: Track): ResponseTrack => ({
   title: track?.name,
   artist: track?.artists?.map((artist) => artist?.name).join(', '),
@@ -33,7 +37,7 @@ export class SpotifyClient {
   private readonly clientId: string;
   private readonly clientSecret: string;
   private readonly refreshToken: string;
-  private accessToken: AccessToken | null = null;
+  private accessToken: string | null = null;
 
   constructor({ clientId, clientSecret, refreshToken }: SpotifyClientOptions) {
     this.clientId = clientId;
@@ -56,22 +60,29 @@ export class SpotifyClient {
       })
     });
     const responseData = (await response.json()) as AccessToken;
-    return responseData;
+    return responseData?.access_token;
   };
 
   getCurrentlyPlaying = async ({
     fallbackToLastPlayed = false
-  }: CurrentlyPlayingOptions = {}) => {
+  }: CurrentlyPlayingOptions = {}): Promise<CurrentlyPlayingResponse | null> => {
     try {
       if(this.accessToken === null) 
         this.accessToken = await this._genAccesToken();
-      const headers = { Authorization: `Bearer ${this.accessToken.access_token}` };
+
+      const headers = { Authorization: `Bearer ${this.accessToken}` };
       const response = await fetch(CURRENTLY_PLAYING_URL, { headers });
+
+      if(response.status === 401) {
+        this.accessToken = await this._genAccesToken();
+        return this.getCurrentlyPlaying({ fallbackToLastPlayed });
+      }
+
       let isPlaying = true;
       if (response.status === 204) {
         isPlaying = false;
         return fallbackToLastPlayed
-          ? { isPlaying, ...(await this.getLastPlayed())[0] as ResponseTrack }
+          ? { isPlaying, ...(await this.getLastPlayed())[0]}
           : null;
       }
       const responseData = (await response.json()) as CurrentlyPlaying;
@@ -91,14 +102,20 @@ export class SpotifyClient {
       if(limit > 50 || limit < 1)
         throw new Error('Limit must be between 1 and 50');
       
-      const headers = { Authorization: `Bearer ${this.accessToken.access_token}` };
+      const headers = { Authorization: `Bearer ${this.accessToken}` };
       const response = await fetch(`${LAST_PLAYED_URL}?limit=${limit}`, { headers });
+
+      if (response.status === 401) {
+        this.accessToken = await this._genAccesToken();
+        return this.getLastPlayed(limit);
+      }
+
       // TODO: add types once spotify-types is updated
       const responseData = (await response.json()) as any;
       const lastPlayedTrack = responseData.items.map((item: { track: Track; }) => {
-        const track = filterResponse(item.track);
-        return track;	
+        return filterResponse(item.track);
       })
+
       return lastPlayedTrack;
     } catch (error: any) {
       throw new Error(error);

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import fetch from 'isomorphic-unfetch';
+import fetch from 'node-fetch';
 import { stringify } from 'node:querystring';
 import type { AccessToken, CurrentlyPlaying, Track } from 'spotify-types';
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "isomorphic-unfetch": "^3.1.0"
+    "node-fetch": "^3.2.2"
   },
   "ava": {
     "extensions": {

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ const lastPlayedTrack = await spotify.getLastPlayed();
  ]
 */
 
-// If you wish to get a list of the recently played songs, pass the limit option, this can be an integer between 1 and 50
+// To get a specific number of the recently played songs, just pass it to the method (1 < n < 50), default is 1
 const recentTracks = await spotify.getLastPlayed(2)
 /**
  [

--- a/readme.md
+++ b/readme.md
@@ -42,11 +42,30 @@ const currentlyPlayingTrack = await spotify.getCurrentlyPlaying();
 // Get the last played track
 const lastPlayedTrack = await spotify.getLastPlayed();
 /**
- {
-    title: '<track title>',
-    artist: '<artist name>',
-    album: '<album name>',
- }
+ [
+    {
+      title: '<track title>',
+      artist: '<artist name>',
+      album: '<album name>',
+   }
+ ]
+*/
+
+// If you wish to get a list of the recently played songs, pass the limit option, this can be an integer between 1 and 50
+const recentTracks = await spotify.getLastPlayed(2)
+/**
+ [
+   {
+      title: '<track title>',
+      artist: '<artist name>',
+      album: '<album name>',
+   },
+   {
+      title: '<track title>',
+      artist: '<artist name>',
+      album: '<album name>',
+   }
+ ]
 */
 
 // If there is no track playing, pass `fallbaclkToLastPlayed` option to get the last played track instead of null
@@ -61,6 +80,8 @@ const currentTrack = await spotify.getCurrentlyPlaying({
     album: '<album name>',
  }
 */
+
+
 ```
 
 <br/>

--- a/test.ts
+++ b/test.ts
@@ -27,10 +27,29 @@ test('SpotifyClient: get last played song', async (t) => {
   const lastPlayed = await spotify.getLastPlayed();
   t.truthy(typeof lastPlayed !== 'undefined');
 
-  t.truthy(typeof lastPlayed?.title === 'string');
-  t.truthy(typeof lastPlayed?.artist === 'string');
-  t.truthy(typeof lastPlayed?.link === 'string');
-  t.truthy(lastPlayed?.title?.length > 0);
-  t.truthy(lastPlayed?.artist?.length > 0);
-  t.truthy(lastPlayed?.link?.length > 0);
+  t.truthy(typeof lastPlayed[0]?.title === 'string');
+  t.truthy(typeof lastPlayed[0]?.artist === 'string');
+  t.truthy(typeof lastPlayed[0]?.link === 'string');
+  t.truthy(lastPlayed[0]?.title?.length > 0);
+  t.truthy(lastPlayed[0]?.artist?.length > 0);
+  t.truthy(lastPlayed[0]?.link?.length > 0);
 });
+
+test('SpotifyClient: get 10 recently played songs', async (t) => {
+  const lastPlayed = await spotify.getLastPlayed(10);
+  t.truthy(typeof lastPlayed !== 'undefined');
+
+  t.truthy(lastPlayed.length === 10);
+  lastPlayed.forEach((track) => {
+    t.truthy(typeof track?.title === 'string');
+    t.truthy(typeof track?.artist === 'string');
+    t.truthy(typeof track?.link === 'string');
+    t.truthy(track?.title?.length > 0);
+    t.truthy(track?.artist?.length > 0);
+    t.truthy(track?.link?.length > 0);
+  });
+})
+
+test('SpotifyClient: get 60 recently played songs. should throw an error', async (t) => {
+  await t.throwsAsync(spotify.getLastPlayed(60));
+})


### PR DESCRIPTION
add caching of the accesToken to the client
add limit to the getLastPlayed function to allow the user to pick the amount of tracks to receive. max being 50 and minimum being 1.
add test to test the limiting feature on getlastPlayed
fixes #10
fixes #7